### PR TITLE
Update to the latest rapidminer gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'com.rapidminer.gradle-plugin' version '0.4.1'
+	id 'com.rapidminer.gradle-plugin' version '0.4.3'
 }
 
 gradlePlugin { id 'code-quality' }


### PR DESCRIPTION
Hiya, I was doing a scan of the Gradle Plugin Portal and noticed you are using an old version of the `plugin-publish-plugin` (0.4.1 of your gradle plugin uses v0.9.4 of the pligin-publish plugin).

There was a [bug in versions prior to 0.9.7](https://discuss.gradle.org/t/plugin-authors-please-use-the-latest-plugin-publish-plugin-others-may-result-in-a-broken-upload/23573), where artifacts would silently not be pushed into the repo, which means the latest version of your plugin will not work properly when people apply it to their build.

Upgrading to the latest version of your `com.rapidminer.gradle-plugin` will fix this, but this will require pushing a new version of this plugin.

1. apply the PR
2. publish a new version of your plugin
3. let us know if you want us to remove the broken version `0.4.3`

Thanks (and sorry about that).

Let us know here [or in the forums](https://discuss.gradle.org/c/help-discuss/plugin-portal) if you need more assistance.